### PR TITLE
Changed to show syntax error when api proxy is enabled.

### DIFF
--- a/app/scripts/components/panel/line/index.js
+++ b/app/scripts/components/panel/line/index.js
@@ -37,7 +37,11 @@ module.exports = Vue.extend({
     },
 
     onError: function (xhr, textStatus, error) {
-      this.chart.error(xhr.status + ':' + xhr.statusText);
+      if (typeof xhr.responseText === 'string' && xhr.responseText.match(/^Error:/)) {
+        this.chart.error(xhr.responseText);
+      } else {
+        this.chart.error(xhr.status + ':' + xhr.statusText);
+      }
     },
 
     timer: function (enable) {

--- a/server/app.js
+++ b/server/app.js
@@ -29,7 +29,10 @@ exports.create = function create(opts) {
     .get(function (req, res, next) {
       var query = req.query.q;
       influxdb.query(query, function (err, data) {
-        if (err) return res.json(500, err);
+        if (err) {
+          res.type('text/plain');
+          return res.send(500, err.toString());
+        }
         res.json(data);
       });
     });


### PR DESCRIPTION
APIのproxyが有効になっている時に、間違った文法のqueryを入力するとエラーの詳細が表示されなかったので、表示するようにしてみました。

スクリーンショット:
http://gyazo.com/874541f4f04b8a83b1dde3d5a37e67ba
