### PR TITLE
Prevent bodyparse's deprecated message

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -19,7 +19,7 @@ exports.create = function create(opts) {
 
   var influxdb = new InfluxDB(opts);
 
-  app.use(bodyParser());
+  app.use(bodyParser.json());
   app.use(compress());
   app.use(express.static(__dirname + '/../../public'));
   app.use(errorhandler());


### PR DESCRIPTION
https://github.com/expressjs/body-parser/commit/b7420f8dc5c8b17a277c9e50d72bbaf3086a3900

`bodyParser()` is deprecated so use `bodyParser.json()` instead of `bodyParser()`
