### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Influga is no longer maintained. Please consider to use alternative, if you are using InfluxDB 0.9+, my recommendation is [re:dash](http://redash.io/)
+# Influga is no longer maintained. Please consider to use alternative, if you are using InfluxDB 0.9+, my recommendation is [re:dash](http://redash.io/)
 
 # Influga [![Build Status](https://travis-ci.org/hakobera/influga.svg?branch=master)](https://travis-ci.org/hakobera/influga)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
